### PR TITLE
Fix: Resizing results in overlapping images

### DIFF
--- a/src/lib/canvasService.ts
+++ b/src/lib/canvasService.ts
@@ -37,6 +37,15 @@ class CanvasServiceSrc {
     this.canvas.height = height;
     this.canvasCtx.drawImage(this.helperCanvas, 0, 0);
   }
+
+  resizeImage(from: {width: number, height: number}, to: {width: number, height: number}) {
+    this.helperCanvas.width = to.width;
+    this.helperCanvas.height = to.height;
+    this.helperCanvasCtx.drawImage(this.canvas, 0, 0, from.width, from.height, 0, 0, to.width, to.width);
+    this.canvas.width = to.width;
+    this.canvas.height = to.height;
+    this.canvasCtx.drawImage(this.helperCanvas, 0, 0);
+  }
 }
 
 export const canvasService = new CanvasServiceSrc();

--- a/src/lib/operators/resize.ts
+++ b/src/lib/operators/resize.ts
@@ -49,11 +49,11 @@ export function resize(options: ResizeOptions): OperatorFunction {
           for (let i = 1; i < downscalingSteps; i++) {
             oldScale         = currentStepScale;
             currentStepScale = currentStepScale * .5;
-            canvasService.canvasCtx.drawImage(canvasService.canvas, 0, 0, oldWidth * oldScale, oldHeight * oldScale, 0, 0, oldWidth * currentStepScale, oldHeight * currentStepScale);
+            canvasService.resizeImage({width: oldWidth * oldScale, height: oldHeight * oldScale}, {width: oldWidth * currentStepScale, height: oldHeight * currentStepScale});
           }
 
           // Down-scaling step i+1 (draw final result)
-          canvasService.canvasCtx.drawImage(canvasService.canvas, 0, 0, oldWidth * currentStepScale, oldHeight * currentStepScale, 0, 0, newWidth, newHeight);
+          canvasService.resizeImage({width: oldWidth * currentStepScale, height: oldHeight * currentStepScale}, {width: newWidth, height: oldHeight * newHeight});
           canvasService.crop(newWidth, newHeight);
         }
       }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
When Resizing images the resize function in resize.js draws in a loop to the same canvas. This can result in multiple overlapping images (with different size) on the same canvas. The cropping function at the end doesn't remove them.

* **What is the current behavior?** (You can also link to an open issue here)
[Resizing results in overlapping images. #12](https://github.com/MickL/ts-image-processor/issues/12)

* **What is the new behavior (if this is a feature change)?**
This is only a bug fix. No change in behavior.